### PR TITLE
Sagemarker does support julia

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of Data Science focused notebook engines
 | MatrixDS     |     | Yes |   |
 | MyBinder     |     | Yes; requires some tricks | Binder  |
 | Kaggle     |     | No| Proprietary  |
-| AWS SageMaker     |     | Not sure; likely not yet | Proprietary  |
+| AWS SageMaker     |     | Yes | Proprietary  |
 | Paper space | https://www.paperspace.com/ | Not sure | Meant to be fast, not tested yet. |
 | Observable | https://Observablehq.com/ | Not sure | magic notebook for exploring data |
 | Pluto | https://github.com/fonsp/Pluto.jl | Only Julia | ⚡ Lightweight reactive notebooks for Julia |


### PR DESCRIPTION
I have used Julia on sagemarker's notebooks.
I don't think I had to do anything to set it up.
This was in 2019.

It is just a hosted Jupyter though.
Or it was in 2019